### PR TITLE
fix: Media query won't working

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="pt-br">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="reset.css">
     <link rel="stylesheet" href="estilo.css">
     <link rel="stylesheet" href="flexcaixa.css">


### PR DESCRIPTION
Ficou faltando configurar a viewport. Você só consegue usar uma media query se informar ao navegador como usar as dimensões! 

Uma media query faz uma consulta ao navegador tipo... 
```css 
@media (max-width: 780px) /* hey! Navegador... se tua tela for até 780px use esse css */
```

Por isso sempre que usarmos esse tipo de consulta devemos configurar a viewport